### PR TITLE
Fix install issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.6
+  NewCops: enable
 
 Style/Documentation:
   Enabled: false

--- a/lib/rspec/query_profiler.rb
+++ b/lib/rspec/query_profiler.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-require "rspec/core"
-require "rspec/query_profiler/example"
-require "rspec/query_profiler/memoized_helpers"
-
 # The namespace for this gem.
 module RSpec
   module QueryProfiler
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
+    PROFILE_LEVEL = ENV["PROFILE"].to_i
+    IGNORED_QUERIES = ["TRANSACTION", "SCHEMA"].freeze
   end
 end
+
+require "rspec/core"
+require "rspec/query_profiler/example"
+require "rspec/query_profiler/memoized_helpers"

--- a/lib/rspec/query_profiler/memoized_helpers.rb
+++ b/lib/rspec/query_profiler/memoized_helpers.rb
@@ -1,106 +1,103 @@
 # frozen_string_literal: true
 
-require "rspec/core/memoized_helpers"
-
 module RSpec
-  module Core
-    module MemoizedHelpers
-      private
+  # TODO: Move this condition to an prepend statement like in example.rb
+  if QueryProfiler::PROFILE_LEVEL.positive?
+    module Core
+      module MemoizedHelpers
+        private
 
-      def query_logger(type:, &block)
-        return yield unless ENV["PROFILE"]&.to_i&.positive?
-        return yield unless type == :subject || query_logger_within_subject?
+        def query_logger(type:, &block)
+          return yield unless type == :subject || query_logger_within_subject?
 
-        RSpec.current_example.instance_variable_set(:@query_logger_within_subject, true)
-        ActiveSupport::Notifications.subscribed(
-          query_logger_callback(type: type),
-          "sql.active_record",
-          &block
-        )
-      end
-
-      def query_logger_within_subject?
-        RSpec.current_example.instance_variable_get(:@query_logger_within_subject)
-      end
-
-      def query_logger_callback(type:)
-        lambda do |*args|
-          query_details = args[4]
-          next if query_details.fetch(:name) == "SCHEMA"
-          next if query_details.fetch(:sql).starts_with?("BEGIN", "SAVEPOINT", "RELEASE SAVEPOINT")
-
-          RSpec.current_example.instance_variable_get(:@query_logger) << {
-            type: type,
-            name: query_details.fetch(:name),
-            sql: query_details.fetch(:sql),
-            binds: query_details.fetch(:type_casted_binds)
-          }
+          RSpec.current_example.instance_variable_set(:@query_logger_within_subject, true)
+          ActiveSupport::Notifications.subscribed(
+            query_logger_callback(type: type),
+            "sql.active_record",
+            &block
+          )
         end
-      end
 
-      module ClassMethods
-        ### QUERY_PROFILER START ###
-        ### QUERY_PROFILER: add `type` argument to distinguise between :subject and :let ###
-        def let(name, type = :let, &block)
-          ### QUERY_PROFILER END ###
-          # We have to pass the block directly to `define_method` to
-          # allow it to use method constructs like `super` and `return`.
-          raise "#let or #subject called without a block" if block.nil?
+        def query_logger_within_subject?
+          RSpec.current_example.instance_variable_get(:@query_logger_within_subject)
+        end
 
-          if :initialize == name
-            raise(
-              "#let or #subject called with a reserved name #initialize"
-            )
+        def query_logger_callback(type:)
+          lambda do |*args|
+            query_details = args[4]
+            next if query_details.fetch(:name).in?(QueryProfiler::IGNORED_QUERIES)
+
+            RSpec.current_example.instance_variable_get(:@query_logger) << {
+              type: type,
+              name: query_details.fetch(:name),
+              sql: query_details.fetch(:sql),
+              binds: query_details.fetch(:type_casted_binds)
+            }
           end
-          our_module = MemoizedHelpers.module_for(self)
+        end
 
-          # If we have a module clash in our helper module
-          # then we need to remove it to prevent a warning.
-          #
-          # Note we do not check ancestor modules (see: `instance_methods(false)`)
-          # as we can override them.
-          our_module.__send__(:remove_method, name) if our_module.instance_methods(false).include?(name)
-          our_module.__send__(:define_method, name, &block)
+        module ClassMethods
+          ### QUERY_PROFILER START: add `type` argument to distinguise between :subject and :let ###
+          def let(name, type = :let, &block)
+            ### QUERY_PROFILER END ###
+            # We have to pass the block directly to `define_method` to
+            # allow it to use method constructs like `super` and `return`.
+            raise "#let or #subject called without a block" if block.nil?
 
-          # If we have a module clash in the example module
-          # then we need to remove it to prevent a warning.
-          #
-          # Note we do not check ancestor modules (see: `instance_methods(false)`)
-          # as we can override them.
-          remove_method(name) if instance_methods(false).include?(name)
+            if :initialize == name
+              raise(
+                "#let or #subject called with a reserved name #initialize"
+              )
+            end
+            our_module = MemoizedHelpers.module_for(self)
 
-          # Apply the memoization. The method has been defined in an ancestor
-          # module so we can use `super` here to get the value.
-          if block.arity == 1
-            define_method(name) { __memoized.fetch_or_store(name) { super(RSpec.current_example, &nil) } }
-          else
-            define_method(name) do
-              __memoized.fetch_or_store(name) do
-                ### QUERY_PROFILER START ###
-                ### QUERY_PROFILER: wrap the subject and let blocks to be able to count their queries ###
-                query_logger(type: type) { super(&nil) }
-                ### QUERY_PROFILER END ###
+            # If we have a module clash in our helper module
+            # then we need to remove it to prevent a warning.
+            #
+            # Note we do not check ancestor modules (see: `instance_methods(false)`)
+            # as we can override them.
+            our_module.__send__(:remove_method, name) if our_module.instance_methods(false).include?(name)
+            our_module.__send__(:define_method, name, &block)
+
+            # If we have a module clash in the example module
+            # then we need to remove it to prevent a warning.
+            #
+            # Note we do not check ancestor modules (see: `instance_methods(false)`)
+            # as we can override them.
+            remove_method(name) if instance_methods(false).include?(name)
+
+            # Apply the memoization. The method has been defined in an ancestor
+            # module so we can use `super` here to get the value.
+            if block.arity == 1
+              define_method(name) { __memoized.fetch_or_store(name) { super(RSpec.current_example, &nil) } }
+            else
+              define_method(name) do
+                __memoized.fetch_or_store(name) do
+                  ### QUERY_PROFILER START: wrap the subject and let blocks to be able to count their queries ###
+                  query_logger(type: type) { super(&nil) }
+                  ### QUERY_PROFILER END ###
+                end
               end
             end
           end
-        end
 
-        # Since the subject becomes a regular `let` after this there is no way to tell which is the subject and
-        # which is just a regular let. (For RSpec it does not matter, renaming all subjects to lets will work just fine)
-        def subject(name = nil, &block)
-          if name
-            ### QUERY_PROFILER START ###
-            let(name, :subject, &block)
-            ### QUERY_PROFILER END ###
-            alias_method :subject, name
+          # Since the subject becomes a regular `let` after this there is no way to tell which is the subject and
+          # which is just a regular let. (For RSpec it does not matter, renaming all subjects to lets will work just fine)
+          def subject(name = nil, &block)
+            if name
+              ### QUERY_PROFILER START ###
+              let(name, :subject, &block)
+              ### QUERY_PROFILER END ###
+              alias_method :subject, name
 
-            self::NamedSubjectPreventSuper.__send__(:define_method, name) do
-              raise NotImplementedError, "`super` in named subjects is not supported"
+              self::NamedSubjectPreventSuper.__send__(:define_method, name) do
+                raise NotImplementedError, "`super` in named subjects is not supported"
+              end
+            else
+              ### QUERY_PROFILER START ###
+              let(:subject, :subject, &block)
+              ### QUERY_PROFILER END ###
             end
-          else
-            ### QUERY_PROFILER START ###
-            let(:subject, :subject, &block)
-            ### QUERY_PROFILER END ###
           end
         end
       end

--- a/rspec-query_profiler.gemspec
+++ b/rspec-query_profiler.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport"


### PR DESCRIPTION
Improvements
- Fixes issues where the gem cannot be installed
- Improve performance by only checking the profile ENV twice on startup instead of checking it for each `let` and `subject` in the testsuite.
- Change level 2, it now only shows queries triggered by the code, not those triggered by the testsuite
- Added level 3, which shows all queries (what was previously level 2)

Degredations
- When using in combination with spring the profile level is cached which requires a reboot of spring to change the profile level. Since it is not used a lot this is minor inconvenience.